### PR TITLE
Add tags for cleaned oak logs

### DIFF
--- a/src/main/resources/data/capybara/tags/blocks/cleaned_oak_logs.json
+++ b/src/main/resources/data/capybara/tags/blocks/cleaned_oak_logs.json
@@ -1,0 +1,5 @@
+{
+	"values": [
+		"capybara:oak_without_bark"
+	]
+}

--- a/src/main/resources/data/capybara/tags/items/cleaned_oak_logs.json
+++ b/src/main/resources/data/capybara/tags/items/cleaned_oak_logs.json
@@ -1,0 +1,5 @@
+{
+	"values": [
+		"capybara:oak_without_bark"
+	]
+}

--- a/src/main/resources/data/minecraft/tags/blocks/oak_logs.json
+++ b/src/main/resources/data/minecraft/tags/blocks/oak_logs.json
@@ -1,0 +1,5 @@
+{
+	"values": [
+		"#capybara:cleaned_oak_logs"
+	]
+}

--- a/src/main/resources/data/minecraft/tags/items/oak_logs.json
+++ b/src/main/resources/data/minecraft/tags/items/oak_logs.json
@@ -1,0 +1,5 @@
+{
+	"values": [
+		"#capybara:cleaned_oak_logs"
+	]
+}


### PR DESCRIPTION
This pull request adds block and item tags for cleaned oak logs (25c0280764cbbd70a1504713aea86b60466525fb), and adds that tag to the block and item tags for oak logs (4fee2d891d0ad7a9c6b293c1ba5d465a880022b6).

Therefore, cleaned oak logs will be in the following block and item tags:

* `#capybara:cleaned_oak_logs`
* `#minecraft:oak_logs`
* `#minecraft:logs`